### PR TITLE
let setting element models from different places

### DIFF
--- a/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/FormController.java
+++ b/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/FormController.java
@@ -184,7 +184,9 @@ public class FormController {
             containerView.addView(section.getView());
 
             for (FormElementController element : section.getElements()) {
-                element.setModel(getModel());
+                if(element.getModel()==null){
+                    element.setModel(getModel());
+                }
                 containerView.addView(element.getView());
             }
         }

--- a/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/FormElementController.java
+++ b/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/FormElementController.java
@@ -42,7 +42,7 @@ public abstract class FormElementController {
         return name;
     }
 
-    void setModel(FormModel model) {
+    public void setModel(FormModel model) {
         this.model = model;
     }
 


### PR DESCRIPTION
Before creating form, Users may need attach data to form elements. So Users can set model of elements before FormController.addFormElementsToView call.