### PR TITLE
Field ID generation

### DIFF
--- a/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/FormActivity.java
+++ b/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/FormActivity.java
@@ -1,6 +1,7 @@
 package com.github.dkharrat.nexusdialog;
 
-import android.app.Activity;
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.FragmentManager;
 import android.os.Bundle;
 import android.view.ViewGroup;
 import android.view.WindowManager.LayoutParams;
@@ -10,8 +11,8 @@ import android.view.WindowManager.LayoutParams;
  * create and manage form fields. If you'd like the Activity to be based on <code>AppCompatActivity</code>, you can use
  * {@link FormWithAppCompatActivity}
  */
-public abstract class FormActivity extends Activity {
-
+public abstract class FormActivity extends FragmentActivity {
+    private static final String MODEL_BUNDLE_KEY = "nd_model";
     private FormController formController;
 
     @Override
@@ -24,6 +25,14 @@ public abstract class FormActivity extends Activity {
         formController = new FormController(this);
         initForm();
 
+        FragmentManager fm = getSupportFragmentManager();
+        FormModel retainedModel = (FormModel) fm.findFragmentByTag(MODEL_BUNDLE_KEY);
+
+        if (retainedModel == null) {
+            retainedModel = formController.getModel();
+            fm.beginTransaction().add(retainedModel, MODEL_BUNDLE_KEY).commit();
+        }
+        formController.setModel(retainedModel);
         recreateViews();
     }
 
@@ -31,7 +40,7 @@ public abstract class FormActivity extends Activity {
      * Reconstructs the form element views. This must be called after form elements are dynamically added or removed.
      */
     protected void recreateViews() {
-        ViewGroup containerView = (ViewGroup)findViewById(R.id.form_elements_container);
+        ViewGroup containerView = (ViewGroup) findViewById(R.id.form_elements_container);
         formController.recreateViews(containerView);
     }
 

--- a/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/FormController.java
+++ b/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/FormController.java
@@ -1,6 +1,7 @@
 package com.github.dkharrat.nexusdialog;
 
 import android.content.Context;
+import android.view.View;
 import android.view.ViewGroup;
 
 import com.github.dkharrat.nexusdialog.controllers.FormSectionController;
@@ -15,6 +16,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * <code>FormController</code> is the main class that manages the form elements of NexusDialog. It provides simple APIs
@@ -30,6 +32,7 @@ public class FormController {
 
     private final Context context;
     private ValidationErrorDisplay validationErrorDisplay;
+    private static final AtomicInteger nextGeneratedViewId = new AtomicInteger(1);
 
     public FormController(Context context) {
         this.context = context;
@@ -59,6 +62,24 @@ public class FormController {
         // unregister listener first to make sure we only have one listener registered.
         getModel().removePropertyChangeListener(modelListener);
         getModel().addPropertyChangeListener(modelListener);
+    }
+
+    /**
+     * Generate an available ID for the view.
+     * Uses the same implementation as {@link View#generateViewId}
+     *
+     * @return the next available view identifier.
+     */
+    public static int generateViewId(){
+        for (;;) {
+            final int result = nextGeneratedViewId.get();
+            // aapt-generated IDs have the high byte nonzero; clamp to the range under that.
+            int newValue = result + 1;
+            if (newValue > 0x00FFFFFF) newValue = 1; // Roll over to 1, not 0.
+            if (nextGeneratedViewId.compareAndSet(result, newValue)) {
+                return result;
+            }
+        }
     }
 
     /**

--- a/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/FormModel.java
+++ b/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/FormModel.java
@@ -1,5 +1,8 @@
 package com.github.dkharrat.nexusdialog;
 
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 
@@ -7,8 +10,7 @@ import java.beans.PropertyChangeSupport;
  * <code>FormModel</code> is an abstract class that represents the backing data for a form. It provides a mechanism
  * for form elements to retrieve their values to display to the user and persist changes to the model upon changes.
  */
-public abstract class FormModel {
-
+public abstract class FormModel extends Fragment {
     private final PropertyChangeSupport propertyChangeSupport = new PropertyChangeSupport(this);
 
     /**
@@ -39,7 +41,14 @@ public abstract class FormModel {
         return getBackingValue(name);
     }
 
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setRetainInstance(true);
+    }
+
     /**
+     *
      * Sets a value for the specified field name. A property change notification is fired to registered listeners if
      * the field's value changed.
      *

--- a/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/FormWithAppCompatActivity.java
+++ b/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/FormWithAppCompatActivity.java
@@ -1,6 +1,7 @@
 package com.github.dkharrat.nexusdialog;
 
 import android.os.Bundle;
+import android.support.v4.app.FragmentManager;
 import android.support.v7.app.AppCompatActivity;
 import android.view.ViewGroup;
 import android.view.WindowManager.LayoutParams;
@@ -10,7 +11,7 @@ import android.view.WindowManager.LayoutParams;
  * like the Activity to be based on the standard Android <code>Activity</code>, you can use {@link FormActivity}
  */
 public abstract class FormWithAppCompatActivity extends AppCompatActivity {
-
+    private static final String MODEL_BUNDLE_KEY = "nd_model";
     private FormController formController;
 
     @Override
@@ -23,6 +24,14 @@ public abstract class FormWithAppCompatActivity extends AppCompatActivity {
         formController = new FormController(this);
         initForm();
 
+        FragmentManager fm = getSupportFragmentManager();
+        FormModel retainedModel = (FormModel) fm.findFragmentByTag(MODEL_BUNDLE_KEY);
+
+        if (retainedModel == null) {
+            retainedModel = formController.getModel();
+            fm.beginTransaction().add(retainedModel, MODEL_BUNDLE_KEY).commit();
+        }
+        formController.setModel(retainedModel);
         recreateViews();
     }
 
@@ -30,7 +39,7 @@ public abstract class FormWithAppCompatActivity extends AppCompatActivity {
      * Reconstructs the form element views. This must be called after form elements are dynamically added or removed.
      */
     protected void recreateViews() {
-        ViewGroup containerView = (ViewGroup)findViewById(R.id.form_elements_container);
+        ViewGroup containerView = (ViewGroup) findViewById(R.id.form_elements_container);
         formController.recreateViews(containerView);
     }
 

--- a/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/DatePickerController.java
+++ b/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/DatePickerController.java
@@ -18,6 +18,8 @@ import android.view.View.OnFocusChangeListener;
 import android.widget.DatePicker;
 import android.widget.EditText;
 
+import com.github.dkharrat.nexusdialog.FormController;
+
 /**
  * Represents a field that allows selecting a specific date via a date picker.
  * <p/>
@@ -25,7 +27,7 @@ import android.widget.EditText;
  * represented by returning {@code null} for the value of the field.
  */
 public class DatePickerController extends LabeledFieldController {
-    private final static int EDIT_TEXT_ID = 1001;
+    private final int editTextId = FormController.generateViewId();
 
     private DatePickerDialog datePickerDialog = null;
     private final SimpleDateFormat displayFormat;
@@ -59,7 +61,7 @@ public class DatePickerController extends LabeledFieldController {
     @Override
     protected View createFieldView() {
         final EditText editText = new EditText(getContext());
-        editText.setId(EDIT_TEXT_ID);
+        editText.setId(editTextId);
 
         editText.setSingleLine(true);
         editText.setInputType(InputType.TYPE_CLASS_DATETIME);
@@ -119,7 +121,7 @@ public class DatePickerController extends LabeledFieldController {
     }
 
     private EditText getEditText() {
-        return (EditText)getView().findViewById(EDIT_TEXT_ID);
+        return (EditText)getView().findViewById(editTextId);
     }
 
     private void refresh(EditText editText) {

--- a/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/EditTextController.java
+++ b/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/EditTextController.java
@@ -7,12 +7,13 @@ import android.text.TextWatcher;
 import android.view.View;
 import android.widget.EditText;
 
+import com.github.dkharrat.nexusdialog.FormController;
+
 /**
  * Represents a field that allows free-form text.
  */
 public class EditTextController extends LabeledFieldController {
-
-    private final static int EDIT_TEXT_ID = 1001;
+    private final int editTextId = FormController.generateViewId();
 
     private int inputType;
     private final String placeholder;
@@ -76,7 +77,7 @@ public class EditTextController extends LabeledFieldController {
      * @return the EditText view associated with this element
      */
     public EditText getEditText() {
-        return (EditText)getView().findViewById(EDIT_TEXT_ID);
+        return (EditText)getView().findViewById(editTextId);
     }
 
     /**
@@ -139,7 +140,7 @@ public class EditTextController extends LabeledFieldController {
     @Override
     protected View createFieldView() {
         final EditText editText = new EditText(getContext());
-        editText.setId(EDIT_TEXT_ID);
+        editText.setId(editTextId);
 
         editText.setSingleLine(!isMultiLine());
         if (placeholder != null) {

--- a/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/SearchableSelectionController.java
+++ b/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/SearchableSelectionController.java
@@ -25,6 +25,7 @@ import android.widget.ArrayAdapter;
 import android.widget.EditText;
 import android.widget.ListView;
 
+import com.github.dkharrat.nexusdialog.FormController;
 import com.github.dkharrat.nexusdialog.R;
 import com.github.dkharrat.nexusdialog.utils.MessageUtil;
 
@@ -40,7 +41,7 @@ import com.github.dkharrat.nexusdialog.utils.MessageUtil;
  * can be represented by returning {@code null} for the value of the field.
  */
 public class SearchableSelectionController extends LabeledFieldController {
-    private final static int EDIT_TEXT_ID = 1001;
+    private final int editTextId = FormController.generateViewId();
 
     private final String placeholder;
     private boolean isFreeFormTextAllowed = true;
@@ -93,7 +94,7 @@ public class SearchableSelectionController extends LabeledFieldController {
 
     protected View createFieldView() {
         final EditText editText = new EditText(getContext());
-        editText.setId(EDIT_TEXT_ID);
+        editText.setId(editTextId);
 
         editText.setSingleLine(true);
         editText.setInputType(InputType.TYPE_CLASS_TEXT);
@@ -224,7 +225,7 @@ public class SearchableSelectionController extends LabeledFieldController {
     }
 
     private EditText getEditText() {
-        return (EditText)getView().findViewById(EDIT_TEXT_ID);
+        return (EditText)getView().findViewById(editTextId);
     }
 
     private void refresh(EditText editText) {

--- a/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/SelectionController.java
+++ b/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/SelectionController.java
@@ -9,6 +9,7 @@ import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
 import android.widget.Spinner;
 
+import com.github.dkharrat.nexusdialog.FormController;
 import com.github.dkharrat.nexusdialog.R;
 
 /**
@@ -20,7 +21,7 @@ import com.github.dkharrat.nexusdialog.R;
  */
 public class SelectionController extends LabeledFieldController {
 
-    private final static int SPINNER_ID = 1001;
+    private final int spinnerId = FormController.generateViewId();
 
     private final String prompt;
     private final List<String> items;
@@ -69,13 +70,13 @@ public class SelectionController extends LabeledFieldController {
      * @return the Spinner view associated with this element
      */
     public Spinner getSpinner() {
-        return (Spinner)getView().findViewById(SPINNER_ID);
+        return (Spinner)getView().findViewById(spinnerId);
     }
 
     @Override
     protected View createFieldView() {
         Spinner spinnerView = new Spinner(getContext());
-        spinnerView.setId(SPINNER_ID);
+        spinnerView.setId(spinnerId);
         spinnerView.setPrompt(prompt);
         ArrayAdapter<String> spinnerAdapter = new ArrayAdapter<String>(getContext(), android.R.layout.simple_spinner_item, items);
         spinnerAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);


### PR DESCRIPTION
The fix wasn't as easy as expected, but I have something. :)

I had to create every field View programmatically, because xml layouts will end with the same bug as #12, i.e. every field of the same type will share the same id, so Android will recognize them as the same and copy values between them on rotation.
So the Idea is that every field has a new ID when created. 

At this point, the rotation creates new fields (thus with different IDs), so their values weren't kept.
I had to make the `FormModel` Serializable in order to save it upon Activity destruction and re-set it on activity creation (which are called on a phone rotation without special treatment).

This will Close #11 