### PR TITLE
readonly mode

### DIFF
--- a/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/FormController.java
+++ b/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/FormController.java
@@ -29,6 +29,7 @@ public class FormController {
     private FormModel model;
     private ValidationErrorDisplay validationErrorDisplay;
     private static final AtomicInteger nextGeneratedViewId = new AtomicInteger(1);
+    private boolean readonly;
 
     /**
      * Constructs a new FormController.
@@ -64,6 +65,32 @@ public class FormController {
         // unregister listener first to make sure we only have one listener registered.
         getModel().removePropertyChangeListener(modelListener);
         getModel().addPropertyChangeListener(modelListener);
+    }
+
+    /**
+     * Sets the readonly flag. If set, all form elements will be switched to readonly-mode.
+     *
+     * @param readonly the new readonly flag
+     */
+    public void setReadonly(boolean readonly)
+    {
+        if (this.readonly != readonly) {
+            /* switch readonly mode in all elements */
+            for (FormSectionController section : getSections()) {
+                section.setReadonly(readonly);
+            }
+        }
+        this.readonly = readonly;
+    }
+
+    /**
+     * Gets the current value of the readonly flag.
+     *
+     * @return
+     */
+    public boolean getReadonly()
+    {
+        return this.readonly;
     }
 
     /**

--- a/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/FormElementController.java
+++ b/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/FormElementController.java
@@ -94,4 +94,12 @@ public abstract class FormElementController {
      * @param message The message to display.
      */
     public abstract void setError(String message);
+
+    /**
+     * Switch element's readonly mode.
+     *
+     * @param readonly if true, element will be readonly.
+     */
+    public abstract void setReadonly(boolean readonly);
+
 }

--- a/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/CheckBoxController.java
+++ b/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/CheckBoxController.java
@@ -6,6 +6,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
+import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 
 import com.github.dkharrat.nexusdialog.FormController;
@@ -27,6 +28,7 @@ public class CheckBoxController extends LabeledFieldController {
     private final int CHECKBOX_ID = FormController.generateViewId();
     private final List<String> items;
     private final List<?> values;
+    private boolean readonly;
 
     /**
      * Constructs a new instance of a checkboxes field.
@@ -106,7 +108,7 @@ public class CheckBoxController extends LabeledFieldController {
     }
 
     @Override
-    protected View createFieldView() {
+    protected View createFieldView(FrameLayout container) {
         LayoutInflater inflater = (LayoutInflater) getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         ViewGroup checkboxContainer = (ViewGroup) inflater.inflate(R.layout.form_checkbox_container, null);
 
@@ -144,6 +146,7 @@ public class CheckBoxController extends LabeledFieldController {
                         areValuesDefined() ? values.get(index) : index
                 )
         );
+        checkbox.setEnabled(!this.readonly);
     }
 
     @Override
@@ -188,4 +191,16 @@ public class CheckBoxController extends LabeledFieldController {
     private ViewGroup getContainer() {
         return (ViewGroup) getView().findViewById(R.id.form_checkbox_container);
     }
+
+    /**
+     * Set readonly mode.
+     *
+     * @param readonly if true, element will be readonly.
+     */
+    public void setReadonly(boolean readonly)
+    {
+        this.readonly = readonly;
+        refresh();
+    }
+
 }

--- a/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/DatePickerController.java
+++ b/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/DatePickerController.java
@@ -12,12 +12,12 @@ import android.app.DatePickerDialog.OnDateSetListener;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnDismissListener;
-import android.text.InputType;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.View.OnFocusChangeListener;
 import android.widget.DatePicker;
 import android.widget.EditText;
+import android.widget.FrameLayout;
 
 import com.github.dkharrat.nexusdialog.FormController;
 import com.github.dkharrat.nexusdialog.validations.InputValidator;
@@ -28,12 +28,13 @@ import com.github.dkharrat.nexusdialog.validations.InputValidator;
  * For the field value, the associated FormModel must return a {@link Date} instance. No selected date can be
  * represented by returning {@code null} for the value of the field.
  */
-public class DatePickerController extends LabeledFieldController {
+public class DatePickerController extends TextController {
     private final int editTextId = FormController.generateViewId();
 
     private DatePickerDialog datePickerDialog = null;
     private final SimpleDateFormat displayFormat;
     private final TimeZone timeZone;
+    private boolean readonly;
 
     /**
      * Constructs a new instance of a date picker field.
@@ -76,14 +77,9 @@ public class DatePickerController extends LabeledFieldController {
     }
 
     @Override
-    protected View createFieldView() {
-        final EditText editText = new EditText(getContext());
-        editText.setId(editTextId);
-
-        editText.setSingleLine(true);
-        editText.setInputType(InputType.TYPE_CLASS_DATETIME);
+    protected View createFieldView(FrameLayout container) {
+        final EditText editText = (EditText) super.createFieldView(container);
         editText.setKeyListener(null);
-        refresh(editText);
         editText.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -104,8 +100,8 @@ public class DatePickerController extends LabeledFieldController {
     }
 
     private void showDatePickerDialog(final Context context, final EditText editText) {
-        // don't show dialog again if it's already being shown
-        if (datePickerDialog == null) {
+        // don't show dialog again if it's already being shown or we're readonly
+        if (!this.readonly && datePickerDialog == null) {
             Date date = (Date)getModel().getValue(getName());
             if (date == null) {
                 date = new Date();
@@ -137,16 +133,4 @@ public class DatePickerController extends LabeledFieldController {
         }
     }
 
-    private EditText getEditText() {
-        return (EditText)getView().findViewById(editTextId);
-    }
-
-    private void refresh(EditText editText) {
-        Date value = (Date)getModel().getValue(getName());
-        editText.setText(value != null ? displayFormat.format(value) : "");
-    }
-
-    public void refresh() {
-        refresh(getEditText());
-    }
 }

--- a/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/EditTextController.java
+++ b/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/EditTextController.java
@@ -6,20 +6,25 @@ import android.text.InputType;
 import android.text.TextWatcher;
 import android.view.View;
 import android.widget.EditText;
+import android.widget.FrameLayout;
+import android.widget.TextView;
 
 import com.github.dkharrat.nexusdialog.FormController;
+import com.github.dkharrat.nexusdialog.R;
 import com.github.dkharrat.nexusdialog.validations.InputValidator;
 
+import java.text.Normalizer;
 import java.util.Set;
 
 /**
  * Represents a field that allows free-form text.
  */
-public class EditTextController extends LabeledFieldController {
-    private final int editTextId = FormController.generateViewId();
+public class EditTextController extends TextController {
 
     private int inputType;
     private final String placeholder;
+    private boolean readonly;
+
 
     /**
      * Constructs a new instance of an edit text field.
@@ -105,15 +110,6 @@ public class EditTextController extends LabeledFieldController {
     }
 
     /**
-     * Returns the EditText view associated with this element.
-     *
-     * @return the EditText view associated with this element
-     */
-    public EditText getEditText() {
-        return (EditText)getView().findViewById(editTextId);
-    }
-
-    /**
      * Returns a mask representing the content input type. Possible values are defined by {@link InputType}.
      *
      * @return a mask representing the content input type
@@ -121,6 +117,18 @@ public class EditTextController extends LabeledFieldController {
     public int getInputType() {
         return inputType;
     }
+
+    /**
+     * placeholder getter.
+     *
+     * @return String containing the current placeholder or null.
+     */
+    public String getPlaceholder()
+    {
+        return placeholder;
+    }
+
+
 
     private void setInputTypeMask(int mask, boolean enabled) {
         if (enabled) {
@@ -170,44 +178,5 @@ public class EditTextController extends LabeledFieldController {
         setInputTypeMask(InputType.TYPE_TEXT_VARIATION_PASSWORD, isSecureEntry);
     }
 
-    @Override
-    protected View createFieldView() {
-        final EditText editText = new EditText(getContext());
-        editText.setId(editTextId);
 
-        editText.setSingleLine(!isMultiLine());
-        if (placeholder != null) {
-            editText.setHint(placeholder);
-        }
-        editText.setInputType(inputType);
-        refresh(editText);
-        editText.addTextChangedListener(new TextWatcher() {
-            @Override
-            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-            }
-
-            @Override
-            public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
-            }
-
-            @Override
-            public void afterTextChanged(Editable editable) {
-                getModel().setValue(getName(), editText.getText().toString());
-            }
-        });
-
-        return editText;
-    }
-
-    private void refresh(EditText editText) {
-        Object value = getModel().getValue(getName());
-        String valueStr = value != null ? value.toString() : "";
-        if (!valueStr.equals(editText.getText().toString()))
-            editText.setText(valueStr);
-    }
-
-    @Override
-    public void refresh() {
-        refresh(getEditText());
-    }
 }

--- a/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/FormSectionController.java
+++ b/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/FormSectionController.java
@@ -199,4 +199,16 @@ public class FormSectionController extends FormElementController {
     public void setError(String message) {
         // No error are possible on a section.
     }
+
+    /**
+     * Set readonly mode of all fields in this section.
+     *
+     * @param readonly if true, element will be readonly.
+     */
+    public void setReadonly(boolean readonly)
+    {
+        for (FormElementController element : this.getElements()) {
+            element.setReadonly(readonly);
+        }
+    }
 }

--- a/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/LabeledFieldController.java
+++ b/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/LabeledFieldController.java
@@ -1,11 +1,15 @@
 package com.github.dkharrat.nexusdialog.controllers;
 
 import android.content.Context;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
+import com.github.dkharrat.nexusdialog.FormController;
 import com.github.dkharrat.nexusdialog.FormElementController;
 import com.github.dkharrat.nexusdialog.R;
 import com.github.dkharrat.nexusdialog.validations.InputValidator;
@@ -131,9 +135,9 @@ public abstract class LabeledFieldController extends FormElementController {
      *
      * @return          the view for this element
      */
-    public View getFieldView() {
+    public View getFieldView(FrameLayout container) {
         if (fieldView == null) {
-            fieldView = createFieldView();
+            fieldView = createFieldView(container);
         }
         return fieldView;
     }
@@ -143,7 +147,7 @@ public abstract class LabeledFieldController extends FormElementController {
      *
      * @return          the newly created view for this field
      */
-    protected abstract View createFieldView();
+    protected abstract View createFieldView(FrameLayout container);
 
     @Override
     protected View createView() {
@@ -159,7 +163,7 @@ public abstract class LabeledFieldController extends FormElementController {
         }
 
         FrameLayout container = (FrameLayout)view.findViewById(R.id.field_container);
-        container.addView(getFieldView());
+        container.addView(getFieldView(container));
 
         return view;
     }
@@ -173,4 +177,5 @@ public abstract class LabeledFieldController extends FormElementController {
             errorView.setVisibility(View.VISIBLE);
         }
     }
+
 }

--- a/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/SearchableSelectionController.java
+++ b/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/SearchableSelectionController.java
@@ -24,6 +24,7 @@ import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemClickListener;
 import android.widget.ArrayAdapter;
 import android.widget.EditText;
+import android.widget.FrameLayout;
 import android.widget.ListView;
 
 import com.github.dkharrat.nexusdialog.FormController;
@@ -53,6 +54,7 @@ public class SearchableSelectionController extends LabeledFieldController {
     private final LoadItemsTask loadItemsTask;
     private ProgressDialog loadingIndicator;
     private boolean otherSelectionIsShowing = false;
+    private boolean readonly;
 
     /**
      * An interface that provides the list of items to display for the {@link SearchableSelectionController}.
@@ -114,7 +116,7 @@ public class SearchableSelectionController extends LabeledFieldController {
         return isFreeFormTextAllowed;
     }
 
-    protected View createFieldView() {
+    protected View createFieldView(FrameLayout container) {
         final EditText editText = new EditText(getContext());
         editText.setId(editTextId);
 
@@ -145,6 +147,10 @@ public class SearchableSelectionController extends LabeledFieldController {
     }
 
     private void showSelectionDialog(final Context context, final EditText editText) {
+        if (this.readonly) {
+            return;
+        }
+
         if (items == null) {
             assert(loadItemsTask.getStatus() != Status.FINISHED);
             loadItemsTask.runTaskOnFinished(new Runnable() {
@@ -253,6 +259,7 @@ public class SearchableSelectionController extends LabeledFieldController {
     private void refresh(EditText editText) {
         String value = (String)getModel().getValue(getName());
         editText.setText(value != null ? value : "");
+        editText.setEnabled(!this.readonly);
     }
 
     @Override
@@ -286,5 +293,16 @@ public class SearchableSelectionController extends LabeledFieldController {
         protected void runTaskOnFinished(Runnable runnable) {
             doneRunnable = runnable;
         }
+    }
+
+    /**
+     * Set readonly mode.
+     *
+     * @param readonly if true, element will be readonly.
+     */
+    public void setReadonly(boolean readonly)
+    {
+        this.readonly = readonly;
+        refresh();
     }
 }

--- a/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/SelectionController.java
+++ b/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/SelectionController.java
@@ -11,6 +11,7 @@ import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
+import android.widget.FrameLayout;
 import android.widget.Spinner;
 import android.widget.TextView;
 
@@ -31,6 +32,7 @@ public class SelectionController extends LabeledFieldController {
     private final String prompt;
     private final List<String> items;
     private final List<?> values;
+    private boolean readonly;
 
     /**
      * Constructs a selection field
@@ -118,7 +120,7 @@ public class SelectionController extends LabeledFieldController {
     }
 
     @Override
-    protected View createFieldView() {
+    protected View createFieldView(FrameLayout container) {
         Spinner spinnerView = new Spinner(getContext());
         spinnerView.setId(spinnerId);
         spinnerView.setPrompt(prompt);
@@ -190,10 +192,22 @@ public class SelectionController extends LabeledFieldController {
         }
 
         spinner.setSelection(selectionIndex);
+        spinner.setEnabled(!this.readonly);
     }
 
     @Override
     public void refresh() {
         refresh(getSpinner());
+    }
+
+    /**
+     * Set readonly mode.
+     *
+     * @param readonly if true, element will be readonly.
+     */
+    public void setReadonly(boolean readonly)
+    {
+       this.readonly = readonly;
+        refresh();
     }
 }

--- a/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/TextController.java
+++ b/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/TextController.java
@@ -1,0 +1,218 @@
+package com.github.dkharrat.nexusdialog.controllers;
+
+import android.content.Context;
+import android.text.Editable;
+import android.text.InputType;
+import android.text.TextWatcher;
+import android.view.View;
+import android.widget.EditText;
+import android.widget.FrameLayout;
+import android.widget.TextView;
+
+import com.github.dkharrat.nexusdialog.FormController;
+import com.github.dkharrat.nexusdialog.validations.InputValidator;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Created by markus on 19.10.17.
+ */
+
+public abstract class TextController extends LabeledFieldController {
+
+    protected final int editTextId = FormController.generateViewId();
+    protected final int textViewId = FormController.generateViewId();
+    protected boolean readonly;
+
+
+    /**
+     * Creates a labeled text field.
+     *
+     * @param ctx           the Android context
+     * @param name          the name of the field
+     * @param labelText     the label to display beside the field. If null, no label is displayed and the field will
+     *                      occupy the entire length of the row.
+     * @param isRequired    indicates whether this field is required. If true, this field checks for a non-empty or
+     *                      non-null value upon validation. Otherwise, this field can be empty.
+     */
+    public TextController(Context ctx, String name, String labelText, boolean isRequired) {
+        super(ctx, name, labelText, isRequired);
+    }
+
+    /**
+     * Creates a labeled text field.
+     *
+     * @param ctx           the Android context
+     * @param name          the name of the field
+     * @param labelText     the label to display beside the field. If null, no label is displayed and the field will
+     *                      occupy the entire length of the row.
+     * @param validators    The list of input validations to add to the field.
+     */
+    public TextController(Context ctx, String name, String labelText, Set<InputValidator> validators) {
+        super(ctx, name, labelText, validators);
+    }
+    /**
+     * Is this a multiline field?
+     *
+     * @return true if it's multiline, false if not.
+     */
+    public boolean isMultiLine()
+    {
+        return false;
+    }
+
+    /**
+     * Return EditText placeholder.
+     *
+     * @return Placeholder string or null
+     */
+    public String getPlaceholder()
+    {
+        return null;
+    }
+
+    /**
+     * Return EditText input type.
+     *
+     * @return EditText input type.
+     */
+    public int getInputType()
+    {
+        return InputType.TYPE_CLASS_TEXT;
+    }
+
+    /**
+     * Returns the EditText view associated with this element.
+     *
+     * @return the EditText view associated with this element
+     */
+    public EditText getEditText() {
+        return (EditText)getView().findViewById(editTextId);
+    }
+
+    /**
+     * return the readonly TextView
+     *
+     * @return
+     */
+    protected TextView getTextView() {
+        return (TextView)getView().findViewById(textViewId);
+    }
+
+
+        /**
+     * create an EditText and its readonly-counterpart TextView for all controls
+     * that use EditText fields (e.g. EditTextController, DatePickerController,
+     * TimePickerController ...)
+     *
+     * The readonly field is transparently created and added to the container.
+     *
+     * @param container The container this field is added to.
+     * @return the EditText instance.
+     */
+    protected View createEditTextFieldView(FrameLayout container) {
+        /* we use a TextView for read only state and an EditText for !readonly... */
+
+        /* create TextView */
+        final TextView textView = new TextView(getContext());
+        textView.setId(textViewId);
+        textView.setSingleLine(!isMultiLine());
+        container.addView(textView);
+
+        /* create EditText */
+        final EditText editText = new EditText(getContext());
+        editText.setId(editTextId);
+
+        editText.setSingleLine(!isMultiLine());
+        if (getPlaceholder() != null) {
+            editText.setHint(getPlaceholder());
+        }
+        editText.setInputType(getInputType());
+        refresh(editText, textView);
+        editText.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+            }
+
+            @Override
+            public void onTextChanged(CharSequence charSequence, int i, int i1, int i2) {
+            }
+
+            @Override
+            public void afterTextChanged(Editable editable) {
+                String text = editText.getText().toString();
+                getModel().setValue(getName(), text);
+            }
+        });
+
+        return editText;
+    }
+
+    /**
+     * Set readonly mode. Setting readonly to true disables editing.
+     *
+     * Note: Android does not support readonly EditText fields. If set to disabled,
+     *       it won't scroll, renderung disabled/readonly EditText fields useless.
+     *       Thus, we add a supplicant TextView that swaps place with the EditText
+     *       as appropriate.
+     *
+     * @param readonly if true, element will be readonly.
+     */
+    public void setReadonly(boolean readonly)
+    {
+        this.readonly = readonly;
+
+        EditText editText = getEditText();
+        TextView textView = getTextView();
+        if (editText == null || textView == null) {
+            return;
+        }
+
+        if (readonly) {
+            textView.setText(editText.getText());
+            editText.setVisibility(View.GONE);
+            textView.setVisibility(View.VISIBLE);
+        } else {
+            editText.setVisibility(View.VISIBLE);
+            textView.setVisibility(View.GONE);
+        }
+
+    }
+
+
+    /**
+     * Refresh fields with current model value.
+     *
+     * @param editText the EditText instance
+     * @param textView the associated TextView instance
+     */
+
+    protected void refresh(EditText editText, TextView textView) {
+        Object value = getModel().getValue(getName());
+        String valueStr = value != null ? value.toString() : "";
+        if (!valueStr.equals(editText.getText().toString())) {
+            editText.setText(valueStr);
+            /* also update the readonly widget */
+            if (textView != null) {
+                textView.setText(valueStr);
+            }
+        }
+
+        editText.setVisibility(this.readonly ? View.GONE : View.VISIBLE);
+        textView.setVisibility(this.readonly ? View.VISIBLE : View.GONE);
+
+    }
+
+    @Override
+    protected View createFieldView(FrameLayout container) {
+        /* we use a TextView for read only state and an EditText for !readonly... */
+        return createEditTextFieldView(container);
+    }
+
+    @Override
+    public void refresh() {
+        refresh(getEditText(), getTextView());
+    }
+
+}

--- a/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/TimePickerController.java
+++ b/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/TimePickerController.java
@@ -6,6 +6,7 @@ import android.content.DialogInterface;
 import android.text.InputType;
 import android.view.View;
 import android.widget.EditText;
+import android.widget.FrameLayout;
 import android.widget.TimePicker;
 
 import com.github.dkharrat.nexusdialog.FormController;
@@ -25,6 +26,7 @@ public class TimePickerController extends LabeledFieldController {
     private final SimpleDateFormat displayFormat;
     private final TimeZone timeZone;
     private final boolean is24HourView;
+    private boolean readonly;
 
     /**
      * Constructs a new instance of a time picker field.
@@ -72,7 +74,7 @@ public class TimePickerController extends LabeledFieldController {
     }
 
     @Override
-    protected View createFieldView() {
+    protected View createFieldView(FrameLayout container) {
         final EditText editText = new EditText(getContext());
         editText.setId(editTextId);
 
@@ -100,8 +102,8 @@ public class TimePickerController extends LabeledFieldController {
     }
 
     private void showTimePickerDialog(Context context, final EditText editText) {
-        // don't show dialog again if it's already being shown
-        if (timePickerDialog == null) {
+        // don't show dialog again if it's already being shown or if we're readonly
+        if (!this.readonly && timePickerDialog == null) {
             Date date = (Date)getModel().getValue(getName());
             if (date == null) {
                 date = new Date();
@@ -140,10 +142,23 @@ public class TimePickerController extends LabeledFieldController {
     private void refresh(EditText editText) {
         Date value = (Date)getModel().getValue(getName());
         editText.setText(value != null ? displayFormat.format(value) : "");
+        editText.setEnabled(!this.readonly);
     }
 
     @Override
     public void refresh() {
         refresh(getEditText());
     }
+
+    /**
+     * Set readonly mode.
+     *
+     * @param readonly if true, element will be readonly.
+     */
+    public void setReadonly(boolean readonly)
+    {
+        this.readonly = readonly;
+        refresh();
+    }
+
 }

--- a/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/ValueController.java
+++ b/nexusdialog/src/main/java/com/github/dkharrat/nexusdialog/controllers/ValueController.java
@@ -3,6 +3,7 @@ package com.github.dkharrat.nexusdialog.controllers;
 import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.widget.FrameLayout;
 import android.widget.TextView;
 import com.github.dkharrat.nexusdialog.R;
 
@@ -26,7 +27,7 @@ public class ValueController extends LabeledFieldController {
     }
 
     @Override
-    protected View createFieldView() {
+    protected View createFieldView(FrameLayout container) {
         LayoutInflater layoutInflater = LayoutInflater.from(getContext());
         final TextView textView = (TextView)layoutInflater.inflate(R.layout.value_field, null);
         refresh(textView);
@@ -46,4 +47,15 @@ public class ValueController extends LabeledFieldController {
     public void refresh() {
         refresh(getTextView());
     }
+
+    /**
+     * Set readonly mode. Does nothing, since this element is readonly by nature.
+     *
+     * @param readonly ignored.
+     */
+    public void setReadonly(boolean readonly)
+    {
+
+    }
+
 }


### PR DESCRIPTION
This PR adds a readonly mode to display items in its current state while preventing accidental edits.
The changes are quite a lot due to the fact that Android's EditText does not have a decent readonly state. Therefore, in readonly mode the code hides the EditText and displays a TextView instead.
Since EditText widgets are also used by DatePicker and TimePicker, I created a TextController class which all controllers using EditText inherit from. Maybe the select controllers should use it, too.